### PR TITLE
Silence warning-6 label omission

### DIFF
--- a/src/ppxfind.ml
+++ b/src/ppxfind.ml
@@ -6,11 +6,11 @@ let split_on_char ~sep s =
   let j = ref (length s) in
   for i = length s - 1 downto 0 do
     if unsafe_get s i = sep then begin
-      r := sub s (i + 1) (!j - i - 1) :: !r;
+      r := sub s ~pos:(i + 1) ~len:(!j - i - 1) :: !r;
       j := i
     end
   done;
-  sub s 0 !j :: !r
+  sub s ~pos:0 ~len:!j :: !r
 
 let linked_in = ["findlib.dynload"; "dynlink"; "ocaml-migrate-parsetree"; "compiler-libs.common"; "str"]
 


### PR DESCRIPTION
Building this on 4.02.3 gives me:

```
❯ ppxfind master* dune build
File "src/jbuild", line 1, characters 0-0:
Warning: jbuild files are deprecated, please convert this file to a dune file instead.
Note: You can use "dune upgrade" to convert your project to dune.
      ocamlc src/.ppxfind.eobjs/byte/ppxfind_findlib_initl_byte.{cmi,cmo,cmt}
    ocamldep src/.ppxfind.eobjs/ppxfind.ml.d
      ocamlc src/.ppxfind.eobjs/byte/ppxfind.{cmi,cmo,cmt} (exit 2)
(cd _build/default && /Users/ec/Sync/Code/Source/ppxfind/_opam/bin/ocamlc.opt -w @a-4-29-40-41-42-44-45-48-58-59-60-40 -strict-sequence -strict-formats -short-paths -keep-locs -g -bin-annot -I src/.ppxfind.eobjs/byte -I /Users/ec/Sync/Code/Source/ppxfind/_opam/lib/findlib -I /Users/ec/Sync/Code/Source/ppxfind/_opam/lib/ocaml-migrate-parsetree -I /Users/ec/Sync/Code/Source/ppxfind/_opam/lib/ocaml/compiler-libs -I /Users/ec/Sync/Code/Source/ppxfind/_opam/lib/ppx_derivers -I /Users/ec/Sync/Code/Source/ppxfind/_opam/lib/result -no-alias-deps -o src/.ppxfind.eobjs/byte/ppxfind.cmo -c -impl src/ppxfind.ml)
File "src/ppxfind.ml", line 9, characters 11-14:
Warning 6: labels were omitted in the application of this function.
File "src/ppxfind.ml", line 13, characters 2-5:
Warning 6: labels were omitted in the application of this function.
File "src/ppxfind.ml", line 1:
Error: Some fatal warnings were triggered (2 occurrences)
```

I added labels on two lines, it fixes those warnings, and enables dune to build `ppxfind.ml`.