### PR TITLE
Adapt to recent changes in OMP

### DIFF
--- a/ppxfind.opam
+++ b/ppxfind.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "dune" {build & >= "1.0"}
-  "ocaml-migrate-parsetree"
+  "ocaml-migrate-parsetree" {>= "1.6.0"}
   "ocamlfind"
   "ocaml" {>= "4.02.3"}
 ]

--- a/src/ppxfind.ml
+++ b/src/ppxfind.ml
@@ -103,8 +103,15 @@ let main () =
     end;
 
     (* Chain to omp *)
-    Sys.argv.(!Arg.current) <- Sys.argv.(0);
-    Migrate_parsetree.Driver.run_main ()
+    let argv =
+      Array.sub
+        Sys.argv
+        ~pos:!Arg.current
+        ~len:(Array.length Sys.argv - !Arg.current)
+    in
+    argv.(0) <- Sys.argv.(0);
+    Migrate_parsetree.Driver.run_main ~argv ();
+    exit 0
   in
   Arg.parse args anon usage;
   prerr_endline "ppxfind: no packages given";


### PR DESCRIPTION
Since https://github.com/ocaml-ppx/ocaml-migrate-parsetree/commit/32defff903b2f5ff3ce91ffce532139179e8b078, OMP's `run_main` has an `?argv` argument for passing the command line to parse. Since https://github.com/ocaml-ppx/ocaml-migrate-parsetree/commit/0d28ffb24a3e555f280971fc6672ef39da439f5a, OMP always starts `Arg`'s parser from argument 0, which means that ppxfind can no longer chain OMP in the old way, and `?argv` must be used.

Without the patch in this PR, using ppxfind with OMP >= 1.6.0 produces errors like [this one](https://ci.ocaml.org/log/saved/docker-run-6eef1e615182b4f547bc0436ae5d1a44/eea15ef6ed20ce0235a9897a51931928da780fb1).